### PR TITLE
feat(columns): implement full column CRUD

### DIFF
--- a/TaskFlow.Api/Controllers/ColumnsController.cs
+++ b/TaskFlow.Api/Controllers/ColumnsController.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
 using TaskFlow.Api.Repository.IRepository;
 
 namespace TaskFlow.Api.Controllers;
@@ -11,55 +12,114 @@ namespace TaskFlow.Api.Controllers;
 [Authorize]
 public class ColumnsController : ControllerBase
 {
-    private readonly ITaskRepository _taskRepository;
+    private readonly IColumnRepository _columnRepository;
 
-    public ColumnsController(ITaskRepository taskRepository)
+    public ColumnsController(IColumnRepository columnRepository)
     {
-        _taskRepository = taskRepository;
+        _columnRepository = columnRepository;
     }
     
     /// <summary>
-    /// Handles an HTTP PATCH request to reorder tasks within a specific column.
+    /// Handles an HTTP POST request to create a new column within a board owned by the authenticated user.
     /// </summary>
-    /// <param name="id">
-    /// The unique identifier of the column whose tasks are being reordered.
-    /// </param>
-    /// <param name="tasksToReorder">
-    /// A collection of task DTOs specifying the task IDs and their new positions.
+    /// <param name="columnDto">
+    /// The data required to create the column, including the column name and the target board ID.
     /// </param>
     /// <returns>
-    /// An <see cref="IActionResult"/> indicating the result of the operation:
+    /// An <see cref="IActionResult"/> describing the result of the operation:
     /// <list type="bullet">
     ///   <item>
     ///     <description><see cref="UnauthorizedResult"/> if the user's identity cannot be verified.</description>
     ///   </item>
     ///   <item>
-    ///     <description><see cref="NotFoundResult"/> if the column does not exist or the user does not own the tasks.</description>
+    ///     <description><see cref="ForbidResult"/> if the board does not belong to the authenticated user.</description>
     ///   </item>
     ///   <item>
-    ///     <description><see cref="NoContentResult"/> if the reorder operation completes successfully.</description>
+    ///     <description><see cref="OkObjectResult"/> containing the newly created column when successful.</description>
     ///   </item>
     /// </list>
     /// </returns>
-    [HttpPatch("{id}/reorder")]
-    public async Task<IActionResult> ReorderTasks(int id, [FromBody] IEnumerable<TaskReorderDto> tasksToReorder)
+    [HttpPost]
+    public async Task<IActionResult> CreateColumn([FromBody] ColumnCreateDto columnDto)
     {
-        // 1. Extract the authenticated user's ID from JWT claims.
-        string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!int.TryParse(userId, out var parsedUserId))
-        {
-            return Unauthorized();
-        }
+        var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!int.TryParse(userIdString, out var userId)) return Unauthorized();
 
-        // 2. Attempt to change the position of the task
-        var wasSuccessful = await _taskRepository.UpdateTaskPositionsAsync(id, tasksToReorder, parsedUserId);
+        var columnToCreate = new Column { Name = columnDto.Name, BoardId = columnDto.BoardId };
+        var createdColumn = await _columnRepository.CreateColumnAsync(columnToCreate, userId);
 
-        // 3. Return 404 if the column doesn't exist or the user doesn't own the tasks.
-        if (!wasSuccessful)
-        {
-            return NotFound("Column not found or you do not have permission to reorder these tasks.");
-        }
+        if (createdColumn == null) return Forbid();
 
-        return NoContent(); 
+        return Ok(createdColumn);
+    }
+
+    /// <summary>
+    /// Handles an HTTP PUT request to update the name of an existing column owned by the authenticated user.
+    /// </summary>
+    /// <param name="id">
+    /// The unique identifier of the column to be updated.
+    /// </param>
+    /// <param name="columnDto">
+    /// The DTO containing the updated column name.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> describing the outcome of the request:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description><see cref="UnauthorizedResult"/> if the user's identity cannot be validated.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><see cref="NotFoundResult"/> if the column does not exist or does not belong to the user.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><see cref="OkObjectResult"/> containing the updated column upon successful update.</description>
+    ///   </item>
+    /// </list>
+    /// </returns>
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateColumn(int id, [FromBody] ColumnUpdateDto columnDto)
+    {
+        var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!int.TryParse(userIdString, out var userId)) return Unauthorized();
+
+        var updatedColumn = await _columnRepository.UpdateColumnAsync(id, columnDto, userId);
+
+        if (updatedColumn == null) return NotFound();
+
+        return Ok(updatedColumn);
+    }
+    
+    /// <summary>
+    /// Handles an HTTP DELETE request to remove a column and all tasks within it, 
+    /// provided the column belongs to the authenticated user.
+    /// </summary>
+    /// <param name="id">
+    /// The unique identifier of the column to delete.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> describing the result:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description><see cref="UnauthorizedResult"/> if user authentication fails.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><see cref="NotFoundResult"/> if the column does not exist or the user does not own it.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><see cref="NoContentResult"/> when the deletion completes successfully.</description>
+    ///   </item>
+    /// </list>
+    /// </returns>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteColumn(int id)
+    {
+        var userIdString = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!int.TryParse(userIdString, out var userId)) return Unauthorized();
+
+        var wasSuccessful = await _columnRepository.DeleteColumnAsync(id, userId);
+
+        if (!wasSuccessful) return NotFound();
+
+        return NoContent();
     }
 }

--- a/TaskFlow.Api/Controllers/TasksController.cs
+++ b/TaskFlow.Api/Controllers/TasksController.cs
@@ -56,6 +56,51 @@ public class TasksController : ControllerBase
     }
     
     /// <summary>
+    /// Handles an HTTP PATCH request to reorder tasks within a specific column.
+    /// </summary>
+    /// <param name="id">
+    /// The unique identifier of the column whose tasks are being reordered.
+    /// </param>
+    /// <param name="tasksToReorder">
+    /// A collection of task DTOs specifying the task IDs and their new positions.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IActionResult"/> indicating the result of the operation:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description><see cref="UnauthorizedResult"/> if the user's identity cannot be verified.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><see cref="NotFoundResult"/> if the column does not exist or the user does not own the tasks.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description><see cref="NoContentResult"/> if the reorder operation completes successfully.</description>
+    ///   </item>
+    /// </list>
+    /// </returns>
+    [HttpPatch("{id}/reorder")]
+    public async Task<IActionResult> ReorderTasks(int id, [FromBody] IEnumerable<TaskReorderDto> tasksToReorder)
+    {
+        // 1. Extract the authenticated user's ID from JWT claims.
+        string? userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!int.TryParse(userId, out var parsedUserId))
+        {
+            return Unauthorized();
+        }
+
+        // 2. Attempt to change the position of the task
+        var wasSuccessful = await _taskRepository.UpdateTaskPositionsAsync(id, tasksToReorder, parsedUserId);
+
+        // 3. Return 404 if the column doesn't exist or the user doesn't own the tasks.
+        if (!wasSuccessful)
+        {
+            return NotFound("Column not found or you do not have permission to reorder these tasks.");
+        }
+
+        return NoContent(); 
+    }
+    
+    /// <summary>
     /// Handles HTTP POST requests to create a new task within a specific column.
     /// </summary>
     /// <param name="taskDto">

--- a/TaskFlow.Api/DTOs/ColumnCreateDto.cs
+++ b/TaskFlow.Api/DTOs/ColumnCreateDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TaskFlow.Api.DTOs;
+
+public class ColumnCreateDto
+{
+    [Required]
+    [MaxLength(50)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public int BoardId { get; set; }
+}

--- a/TaskFlow.Api/DTOs/ColumnUpdateDto.cs
+++ b/TaskFlow.Api/DTOs/ColumnUpdateDto.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TaskFlow.Api.DTOs;
+
+public class ColumnUpdateDto
+{
+    [Required]
+    [MaxLength(50)]
+    public string Name { get; set; } = string.Empty;
+}

--- a/TaskFlow.Api/Program.cs
+++ b/TaskFlow.Api/Program.cs
@@ -21,6 +21,7 @@ public class Program
         builder.Services.AddScoped<IPasswordHasher, PBKDF2PasswordHasher>();
         builder.Services.AddScoped<IUserRepository, UserRepository>();
         builder.Services.AddScoped<IBoardRepository, BoardRepository>();
+        builder.Services.AddScoped<IColumnRepository, ColumnRepository>();
         builder.Services.AddScoped<ITaskRepository, TaskRepository>();
         builder.Services.AddScoped<ITokenService, TokenService>();
         builder.Services.AddDbContext<ApplicationDbContext>(options =>

--- a/TaskFlow.Api/Repository/ColumnRepository.cs
+++ b/TaskFlow.Api/Repository/ColumnRepository.cs
@@ -1,0 +1,62 @@
+using Microsoft.EntityFrameworkCore;
+using TaskFlow.Api.Data;
+using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
+using TaskFlow.Api.Repository.IRepository;
+
+namespace TaskFlow.Api.Repository;
+
+public class ColumnRepository : IColumnRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public ColumnRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+    
+    /// <inheritdoc />
+    public async Task<Column?> CreateColumnAsync(Column column, int userId)
+    {
+        // 1. Verify that the user owns the board the column belongs to.
+        var boardExists = await _context.Boards.AnyAsync(b => b.Id == column.BoardId && b.UserId == userId);
+        if (!boardExists) return null;
+
+        // 2. Add the column and save changes.
+        _context.Columns.Add(column);
+        await _context.SaveChangesAsync();
+        return column;
+    }
+
+    /// <inheritdoc />
+    public async Task<Column?> UpdateColumnAsync(int columnId, ColumnUpdateDto columnDto, int userId)
+    {
+        // 1. Retrieve the column and ensure the user owns the board it belongs to.
+        var column = await _context.Columns
+            .Include(c => c.Board)
+            .FirstOrDefaultAsync(c => c.Id == columnId && c.Board.UserId == userId);
+
+        if (column == null) return null;
+
+        // 2. Update the column name and persist changes.
+        column.Name = columnDto.Name;
+        await _context.SaveChangesAsync();
+        return column;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteColumnAsync(int columnId, int userId)
+    {
+        // 1. Retrieve the column and ensure the user owns the board it belongs to.
+        var column = await _context.Columns
+            .Include(c => c.Board)
+            .FirstOrDefaultAsync(c => c.Id == columnId && c.Board.UserId == userId);
+
+        if (column == null) return false;
+
+        // 2. Delete the column and commit changes.
+        _context.Columns.Remove(column);
+        await _context.SaveChangesAsync();
+        return true;
+    }
+}

--- a/TaskFlow.Api/Repository/IRepository/IColumnRepository.cs
+++ b/TaskFlow.Api/Repository/IRepository/IColumnRepository.cs
@@ -1,0 +1,50 @@
+using TaskFlow.Api.DTOs;
+using TaskFlow.Api.Models;
+
+namespace TaskFlow.Api.Repository.IRepository;
+
+public interface IColumnRepository
+{
+    /// <summary>
+    /// Creates a new column within a board owned by the specified user.
+    /// </summary>
+    /// <param name="column">The column entity to create.</param>
+    /// <param name="userId">
+    /// The ID of the authenticated user attempting to create the column.  
+    /// Ensures that users can only add columns to their own boards.
+    /// </param>
+    /// <returns>
+    /// The newly created <see cref="Column"/> if the board exists and is owned by the user;  
+    /// otherwise, <c>null</c>.
+    /// </returns>
+    Task<Column?> CreateColumnAsync(Column column, int userId);
+    
+    /// <summary>
+    /// Updates the name of an existing column owned by the authenticated user.
+    /// </summary>
+    /// <param name="columnId">The ID of the column to update.</param>
+    /// <param name="columnDto">The data containing the new column name.</param>
+    /// <param name="userId">
+    /// The ID of the user attempting the update.  
+    /// Ensures that a user can only modify their own columns.
+    /// </param>
+    /// <returns>
+    /// The updated <see cref="Column"/> if the column exists and is owned by the user;  
+    /// otherwise, <c>null</c>.
+    /// </returns>
+    Task<Column?> UpdateColumnAsync(int columnId, ColumnUpdateDto columnDto, int userId);
+    
+    /// <summary>
+    /// Deletes a column belonging to a board owned by the authenticated user.
+    /// </summary>
+    /// <param name="columnId">The ID of the column to delete.</param>
+    /// <param name="userId">
+    /// The ID of the user performing the deletion.  
+    /// Used to validate ownership of the board and its columns.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the column existed and was successfully deleted;  
+    /// <c>false</c> if the column does not exist or does not belong to the user.
+    /// </returns>
+    Task<bool> DeleteColumnAsync(int columnId, int userId);
+}

--- a/TaskFlow.Web/src/app/core/services/board.ts
+++ b/TaskFlow.Web/src/app/core/services/board.ts
@@ -7,6 +7,7 @@ import { TaskReorder } from '../../models/task-reorder.model';
 import { TaskCreate } from '../../models/task-create.model';
 import { Task } from '../../models/task.model';
 import { TaskUpdate } from '../../models/task-update.model';
+import { Column } from '../../models/column.model';
 
 /**
  * BoardService handles board-related operations.
@@ -63,6 +64,36 @@ export class BoardService {
    */
   deleteBoard(boardId: number): Observable<void> {
     return this.http.delete<void>(`${this.boardsApiUrl}/${boardId}`);
+  }
+
+  // ========================================
+  // Columns Region
+  // ========================================
+
+  /**
+   * Creates a new column in a specific board.
+   * @param boardId The ID of the board.
+   * @param name The name of the new column.
+   */
+  createColumn(boardId: number, name: string): Observable<Column> {
+    return this.http.post<Column>(this.columnsApiUrl, { boardId, name });
+  }
+
+  /**
+   * Updates the name of an existing column.
+   * @param columnId The ID of the column to update.
+   * @param name The new name for the column.
+   */
+  updateColumn(columnId: number, name: string): Observable<Column> {
+    return this.http.put<Column>(`${this.columnsApiUrl}/${columnId}`, { name });
+  }
+
+  /**
+   * Deletes a column and all its tasks.
+   * @param columnId The ID of the column to delete.
+   */
+  deleteColumn(columnId: number): Observable<void> {
+    return this.http.delete<void>(`${this.columnsApiUrl}/${columnId}`);
   }
 
   // ========================================

--- a/TaskFlow.Web/src/app/core/services/board.ts
+++ b/TaskFlow.Web/src/app/core/services/board.ts
@@ -85,7 +85,7 @@ export class BoardService {
    * @param payload The array of tasks with their new positions.
    */
   reorderTasks(columnId: number, payload: TaskReorder[]): Observable<void> {
-    const reorderUrl = `${this.columnsApiUrl}/${columnId}/reorder`;
+    const reorderUrl = `${this.tasksApiUrl}/${columnId}/reorder`;
     return this.http.patch<void>(reorderUrl, payload);
   }
 

--- a/TaskFlow.Web/src/app/features/boards/board-detail/board-detail.html
+++ b/TaskFlow.Web/src/app/features/boards/board-detail/board-detail.html
@@ -56,6 +56,20 @@
       </ul>
     </div>
     }
+
+    <div class="column add-column">
+    <form [formGroup]="addColumnForm" (ngSubmit)="onAddColumn()">
+      <input 
+        type="text" 
+        formControlName="name" 
+        placeholder="+ Add another list"
+        class="add-column-input"
+      >
+       @if (addColumnForm.dirty && addColumnForm.value.name) {
+          <button type="submit" [disabled]="addColumnForm.invalid">Add List</button>
+       }
+    </form>
+  </div>
   </div>
   }
 </div>

--- a/TaskFlow.Web/src/app/features/boards/board-detail/board-detail.html
+++ b/TaskFlow.Web/src/app/features/boards/board-detail/board-detail.html
@@ -35,7 +35,27 @@
   <div class="columns-container" cdkDropListGroup>
     @for (column of board.columns; track column.id) {
     <div class="column">
-      <h3>{{ column.name }}</h3>
+      <div class="column-header">
+        @if (editingColumnId === column.id) {
+        <input
+          class="column-name-input"
+          [formControl]="editColumnNameControl"
+          (keyup.enter)="onUpdateColumnName(column)"
+          (blur)="onUpdateColumnName(column)"
+          autofocus
+          maxlength="50"
+        />
+        } @else {
+        <h3>
+          <span (click)="startEditingColumn(column)" title="Click to rename">
+            {{ column.name }} </span
+          >
+          <button class="delete-column-btn" (click)="onDeleteColumn(column.id)">
+            Delete Column
+          </button>
+        </h3>
+        }
+      </div>
 
       <form [formGroup]="newTaskForms.get(column.id)!" (ngSubmit)="onCreateTask(column)">
         <input type="text" formControlName="title" placeholder="New task..." />
@@ -58,18 +78,18 @@
     }
 
     <div class="column add-column">
-    <form [formGroup]="addColumnForm" (ngSubmit)="onAddColumn()">
-      <input 
-        type="text" 
-        formControlName="name" 
-        placeholder="+ Add another list"
-        class="add-column-input"
-      >
-       @if (addColumnForm.dirty && addColumnForm.value.name) {
-          <button type="submit" [disabled]="addColumnForm.invalid">Add List</button>
-       }
-    </form>
-  </div>
+      <form [formGroup]="addColumnForm" (ngSubmit)="onAddColumn()">
+        <input
+          type="text"
+          formControlName="name"
+          placeholder="+ Add another list"
+          class="add-column-input"
+        />
+        @if (addColumnForm.dirty && addColumnForm.value.name) {
+        <button type="submit" [disabled]="addColumnForm.invalid">Add List</button>
+        }
+      </form>
+    </div>
   </div>
   }
 </div>


### PR DESCRIPTION
This pull request implements the full-stack functionality for creating, updating (renaming), and deleting columns.

**Backend:**
* Created `ColumnCreateDto` and `ColumnUpdateDto`.
* Implemented `IColumnRepository` and `ColumnRepository` with security checks for board ownership.
* Added secure `POST`, `PUT`, and `DELETE` endpoints to the `ColumnsController`.

**Frontend:**
* Updated `BoardService` with methods for `createColumn`, `updateColumn`, and `deleteColumn`.
* Implemented a form in `BoardDetailComponent` for quickly adding new columns.
* Added "click-to-edit" functionality for column names using Reactive Forms.
* Added a delete button to each column header with a confirmation prompt.
* The UI optimistically updates for all actions, providing a responsive user experience.

Closes #26